### PR TITLE
Plugin borken due to usePreference #4

### DIFF
--- a/frontend/latest/package.json
+++ b/frontend/latest/package.json
@@ -6,7 +6,7 @@
   "omSupplyPlugin": {
     "target": "frontend",
     "types": [
-      "prescriptionPaymentForm"
+      "forecastQuantites"
     ]
   },
   "version": "1.0.0",

--- a/frontend/latest/src/ForecastQuantity/ForecastQuantityField.tsx
+++ b/frontend/latest/src/ForecastQuantity/ForecastQuantityField.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import {
   ArrayElement,
   Plugins,
-  PreferenceKey,
   QueryClientProviderProxy,
   ThemeProviderProxy,
   UNDEFINED_STRING_VALUE,
-  usePreference,
   useTranslation,
 } from '@openmsupply-client/common';
 import { ValueInfoRow } from '@openmsupply-client/requisitions/src/common';
@@ -30,9 +28,6 @@ const ForecastQuantityField: ForecastQuantityFieldPlugin = ({
     },
     queryKey: [line.id],
   });
-  const { data: preferences } = usePreference(
-    PreferenceKey.ManageVaccinesInDoses
-  );
   const t = useTranslation();
 
   const parsed = JSON.parse(data?.[0]?.data ?? '{}');
@@ -52,7 +47,7 @@ const ForecastQuantityField: ForecastQuantityFieldPlugin = ({
           unitName={unitName ?? ''}
           defaultPackSize={1}
           nullDisplay={UNDEFINED_STRING_VALUE}
-          displayVaccinesInDoses={preferences?.manageVaccinesInDoses}
+          displayVaccinesInDoses={true}
           dosesPerUnit={line?.item?.doses}
         />
       </QueryClientProviderProxy>


### PR DESCRIPTION
Closes #4 and Application crashes when accessing an item which is supposed to show the forecasting population plugin #9341

I've removed the preference for now since I'm assuming if they have the plugin all their stores would be using this preference 👀 but this is a change that went into 2.11... so it should work for anyone using 2.10 and has the 

`  const { data: preferences } = usePreference(
    PreferenceKey.ManageVaccinesInDoses
  );`

code still in the plugin...